### PR TITLE
docs: Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,11 @@ export function Button({ primary, ...props }) {
 | minify         | Minify the output css                                                                                                                               | Inferred from [webpack mode](https://webpack.js.org/concepts/#mode). Defaults to `true` if `production` mode.                              |
 | browsers       | A [browserslist](https://github.com/browserslist/browserslist) query to pass to [autoprefixer](https://github.com/postcss/autoprefixer)             | By default, your browserslist query will be resolved from your [browserslist config](https://github.com/browserslist/browserslist#queries) |
 
+## Thanks
+
+- [Johannes Ewald](https://twitter.com/Jhnnns) for letting us have the `treat` name on npm.
+- [Nathan Nam Tran](https://twitter.com/naistran) for creating [css-in-js-loader](https://github.com/naistran/css-in-js-loader), which served as the initial starting point for our approach.
+
 ## License
 
 MIT.


### PR DESCRIPTION
This PR makes the following changes to the readme:

- Fixes default values for `localIdentName` and `themeIdentName`.
- Renames "Low-level API" to "Runtime API", moves it above the React API.
- Avoids use of "we".
- Adds top level "Setup" section.
- Moves webpack plugin API docs into the API Reference section.
- Simplifies webpack setup guide now that defaults are more sensible.