### PR TITLE
fix: Don't publish global theme declaration

### DIFF
--- a/packages/treat/.npmignore
+++ b/packages/treat/.npmignore
@@ -2,3 +2,4 @@ node_modules
 src
 tests
 tsconfig.json
+theme.d.ts


### PR DESCRIPTION
This is a short term fix to stop the default theme clashing with user-provided ones. 