### PR TITLE
fix(babel): Traverse objects to resolve debugIdent name

### DIFF
--- a/packages/babel-plugin-treat/index.test.js
+++ b/packages/babel-plugin-treat/index.test.js
@@ -66,18 +66,22 @@ describe('babel plugin', () => {
         import { style } from 'treat';
 
         const test = {
-          two: style({
-            zIndex: 2,
-          })
+          one: {
+            two: style({
+              zIndex: 2,
+            })
+          }
         };
     `;
 
     expect(transform(source)).toMatchInlineSnapshot(`
                   "import { style } from 'treat';
                   const test = {
-                    two: style({
-                      zIndex: 2
-                    }, \\"two\\")
+                    one: {
+                      two: style({
+                        zIndex: 2
+                      }, \\"test_one_two\\")
+                    }
                   };"
             `);
   });


### PR DESCRIPTION
Makes the debug ident name output by the babel plugin more descriptive by traversing the object. For example, the following previously would result in a debug name of `top`. 
```js
const margin = {
  top: style(...)
};
```
This now resolves to `margin_top`