### PR TITLE
fix: Mark loader as cacheable

### DIFF
--- a/packages/treat/webpack-plugin/loader.js
+++ b/packages/treat/webpack-plugin/loader.js
@@ -103,12 +103,12 @@ const compileTreatSource = (loader, request) =>
   });
 
 module.exports = function(source) {
-  this.cacheable(false);
+  this.cacheable(true);
   return source;
 };
 
 module.exports.pitch = function(request) {
-  this.cacheable(false);
+  this.cacheable(true);
   const callback = this.async();
 
   produce(this, request)


### PR DESCRIPTION
Previously, I had misunderstood how webpack loader caching worked and thought the loader needed to be marked uncacheable. The is not the case and can be reverted back to cacheable. This should drastically increase the speed of the dev experience.