### PR TITLE
fix: Add theme.d.ts to npm package

### DIFF
--- a/docs/data-types.md
+++ b/docs/data-types.md
@@ -139,7 +139,8 @@ If your `Theme` type is already defined elsewhere in your application, you'll ne
 
 ```tsx
 declare module 'treat/theme' {
-  export type Theme = import('./types').Theme;
+  type MyTheme = import('./types').Theme;
+  export interface Theme extends MyTheme {}
 }
 ```
 

--- a/packages/treat/.npmignore
+++ b/packages/treat/.npmignore
@@ -2,4 +2,3 @@ node_modules
 src
 tests
 tsconfig.json
-theme.d.ts

--- a/packages/treat/package.json
+++ b/packages/treat/package.json
@@ -5,10 +5,6 @@
   "main": "lib/commonjs",
   "module": "lib/module",
   "browser": "lib/module/browser",
-  "files": [
-    "lib",
-    "theme.d.ts"
-  ],
   "sideEffects": false,
   "scripts": {
     "build:module": "tsc --module es2015 --outDir lib/module",

--- a/packages/treat/package.json
+++ b/packages/treat/package.json
@@ -5,6 +5,10 @@
   "main": "lib/commonjs",
   "module": "lib/module",
   "browser": "lib/module/browser",
+  "files": [
+    "lib",
+    "theme.d.ts"
+  ],
   "sideEffects": false,
   "scripts": {
     "build:module": "tsc --module es2015 --outDir lib/module",

--- a/packages/treat/src/builder.ts
+++ b/packages/treat/src/builder.ts
@@ -2,7 +2,7 @@ import { fromPairs, isEqual } from 'lodash';
 import dedent from 'dedent';
 import { stringify } from 'javascript-stringify';
 
-import { Theme } from 'treat/theme';
+import { ThemeOrAny } from 'treat/theme';
 import {
   ClassRef,
   Style,
@@ -126,7 +126,7 @@ const createThemedCss = (classRef: ClassRef, style: ThemeStyleMap) => {
 };
 
 export function style(
-  style: ThemedStyle<Style, Theme>,
+  style: ThemedStyle<Style, ThemeOrAny>,
   localDebugName?: string,
 ): ClassRef {
   const localName = localDebugName || 'style';
@@ -161,7 +161,7 @@ export function style(
 
 type StyleMapParam<ClassName extends string> = ThemedStyle<
   StyleMap<ClassName, Style>,
-  Theme
+  ThemeOrAny
 >;
 export function styleMap<ClassName extends string>(
   stylesheet: StyleMapParam<ClassName>,
@@ -226,7 +226,7 @@ export function styleMap<ClassName extends string>(
   return classRefs;
 }
 
-export function createTheme(tokens: Theme, localDebugName?: string): ThemeRef {
+export function createTheme(tokens: ThemeOrAny, localDebugName?: string): ThemeRef {
   const theme = {
     themeRef: getIdentName(localDebugName || 'theme', getNextScope(), tokens),
     tokens,
@@ -239,7 +239,7 @@ export function createTheme(tokens: Theme, localDebugName?: string): ThemeRef {
 
 export function globalStyle(
   selector: string,
-  style: ThemedStyle<GlobalStyle, Theme>,
+  style: ThemedStyle<GlobalStyle, ThemeOrAny>,
 ): void {
   if (isThemedSelector(selector)) {
     getThemes().forEach(theme => {
@@ -276,7 +276,7 @@ export function globalStyle(
 }
 
 type MakeStyleTree<ReturnType> = (
-  theme: Theme,
+  theme: ThemeOrAny,
   styleNode: (style: Style, localDebugName?: string) => ClassRef,
 ) => ReturnType;
 

--- a/packages/treat/src/processSelectors.ts
+++ b/packages/treat/src/processSelectors.ts
@@ -1,4 +1,4 @@
-import { Theme } from 'treat/theme';
+import { ThemeOrAny } from 'treat/theme';
 import mapKeys from 'lodash/mapKeys';
 import flatMap from 'lodash/flatMap';
 import uniq from 'lodash/uniq';
@@ -48,7 +48,7 @@ export const interpolateSelector = (selector: string, themeRef?: ThemeRef) => {
 
 export const combinedThemeSelector = (
   selector: string,
-  themes: Array<TreatTheme<Theme>>,
+  themes: Array<TreatTheme<ThemeOrAny>>,
 ) => {
   if (isThemedSelector(selector)) {
     return uniq(
@@ -65,7 +65,7 @@ export const combinedThemeSelector = (
 
 interface ProcessSelectorsParams {
   style: Style;
-  themes: Array<TreatTheme<Theme>>;
+  themes: Array<TreatTheme<ThemeOrAny>>;
   themeRef?: ThemeRef;
 }
 export const processSelectors = ({

--- a/packages/treat/src/types.ts
+++ b/packages/treat/src/types.ts
@@ -1,5 +1,5 @@
 import { Properties } from 'csstype';
-import { Theme } from 'treat/theme';
+import { ThemeOrAny } from 'treat/theme';
 import { SimplePseudos } from './transformCSS';
 
 export type PostCSS = object;
@@ -76,7 +76,7 @@ export type TreatModule = TreatModuleObject | TreatModuleArray;
 export interface WebpackTreat {
   addLocalCss: (css: object) => void;
   addThemedCss: (themeRef: ThemeRef, css: object) => void;
-  addTheme: (theme: TreatTheme<Theme>) => void;
-  getThemes: () => Array<TreatTheme<Theme>>;
-  getIdentName: (local: string, scopeId: number, theme?: Theme) => string;
+  addTheme: (theme: TreatTheme<ThemeOrAny>) => void;
+  getThemes: () => Array<TreatTheme<ThemeOrAny>>;
+  getIdentName: (local: string, scopeId: number, theme?: ThemeOrAny) => string;
 }

--- a/packages/treat/src/webpackTreat.ts
+++ b/packages/treat/src/webpackTreat.ts
@@ -1,9 +1,9 @@
-import { Theme } from 'treat/theme';
+import { ThemeOrAny } from 'treat/theme';
 import { WebpackTreat, TreatTheme } from './types';
 
 let scopeCount = 0;
 
-const mockThemes: Array<TreatTheme<Theme>> = [];
+const mockThemes: Array<TreatTheme<ThemeOrAny>> = [];
 let webpackTreat: WebpackTreat = {
   addLocalCss: () => {},
   addThemedCss: () => {},

--- a/packages/treat/theme.d.ts
+++ b/packages/treat/theme.d.ts
@@ -1,3 +1,7 @@
+type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
+
 declare module 'treat/theme' {
   export interface Theme {}
+  export type ThemeOrAny = AnyIfEmpty<Theme>
 }
+

--- a/packages/treat/theme.d.ts
+++ b/packages/treat/theme.d.ts
@@ -1,3 +1,3 @@
 declare module 'treat/theme' {
-  export type Theme = any;
+  export interface Theme {}
 }


### PR DESCRIPTION
I was getting these errors:

```
ERROR in <project>/node_modules/treat/lib/commonjs/builder.d.ts(1,23):
TS2307: Cannot find module 'treat/theme'.
ERROR in <project>/node_modules/treat/lib/commonjs/types.d.ts(2,23):
TS2307: Cannot find module 'treat/theme'.
```

These errors appear to be caused by `theme.d.ts` in `packages/treat` not being published along with the rest of the package - you can verify `theme.d.ts` is missing from the published package on [unpkg](https://unpkg.com/browse/treat@1.0.3/).

I verified the code changes in this PR includes `theme.d.ts` by running `npm pack`.

I verified by manually copying `theme.d.ts` tp `node_modules/treat/theme.d.ts` that fixes the above errors.
