### PR TITLE
fix: Handle tree shaking of themes

### DIFF
--- a/packages/treat/tests/__snapshots__/stylesheet.test.ts.snap
+++ b/packages/treat/tests/__snapshots__/stylesheet.test.ts.snap
@@ -1361,6 +1361,10 @@ exports[`Stylesheet Unused modules - Autoprefixer (iOS 8) - should create a dete
     height: 100px;
     width: 100px
 }
+._2dq_B_1KLs {
+    top: 100px;
+    bottom: 100px
+}
 "
 `;
 
@@ -1368,6 +1372,10 @@ exports[`Stylesheet Unused modules - Custom idents - should create a determinist
 ".used-used_1tscQ {
     height: 100px;
     width: 100px
+}
+.usedThemeStyle-usedThemeStyle_2dq_B-theme_1K {
+    top: 100px;
+    bottom: 100px
 }
 "
 `;
@@ -1381,11 +1389,20 @@ exports[`Stylesheet Unused modules - Development mode - should create a determin
     height: 100px;
     width: 100px
 }
+.usedThemeStyle-usedThemeStyle_2dq_B_theme-theme_1KLs {
+    top: 100px;
+    bottom: 100px
+}
+.usedThemeStyle-usedThemeStyle_2dq_B_unusedTheme-unusedTheme_1oZa {
+    top: 100px;
+    bottom: 100px
+}
 "
 `;
 
 exports[`Stylesheet Unused modules - Production mode - should create a deterministic stylesheet 1`] = `
 "._1tscQ{height:100px;width:100px}
+._2dq_B_1KLs{top:100px;bottom:100px}
 "
 `;
 
@@ -1393,6 +1410,10 @@ exports[`Stylesheet Unused modules - Theme function ident - should create a dete
 "._1tscQ {
     height: 100px;
     width: 100px
+}
+._2dq_B_empty-theme_1K {
+    top: 100px;
+    bottom: 100px
 }
 "
 `;

--- a/packages/treat/tests/__snapshots__/styling.test.ts.snap
+++ b/packages/treat/tests/__snapshots__/styling.test.ts.snap
@@ -246,24 +246,30 @@ Object {
 
 exports[`Styling and specificity Unused modules - development mode (style-loader) should be styled correctly 1`] = `
 Object {
+  "bottom": "100px",
   "display": "block",
   "height": "100px",
+  "top": "100px",
   "width": "100px",
 }
 `;
 
 exports[`Styling and specificity Unused modules - mini-css-extract-loader should be styled correctly 1`] = `
 Object {
+  "bottom": "100px",
   "display": "block",
   "height": "100px",
+  "top": "100px",
   "width": "100px",
 }
 `;
 
 exports[`Styling and specificity Unused modules - style-loader should be styled correctly 1`] = `
 Object {
+  "bottom": "100px",
   "display": "block",
   "height": "100px",
+  "top": "100px",
   "width": "100px",
 }
 `;

--- a/packages/treat/tests/fixtures/unused-modules/index.ts
+++ b/packages/treat/tests/fixtures/unused-modules/index.ts
@@ -1,11 +1,16 @@
 import { resolveClassName } from 'treat';
 
-import theme from './theme.treat';
-import { usedStyle } from './lookup';
+import { theme, usedStyle, usedThemeStyle } from './lookup';
 
 const node = document.createElement('div');
 
 node.setAttribute('id', 'main');
-node.setAttribute('class', resolveClassName(theme, usedStyle));
+node.setAttribute(
+  'class',
+  `${resolveClassName(theme, usedStyle)}  ${resolveClassName(
+    theme,
+    usedThemeStyle,
+  )}`,
+);
 
 document.body.appendChild(node);

--- a/packages/treat/tests/fixtures/unused-modules/lookup.ts
+++ b/packages/treat/tests/fixtures/unused-modules/lookup.ts
@@ -1,2 +1,5 @@
 export { default as unusedStyle } from './unused.treat';
+export { default as usedThemeStyle } from './usedThemeStyle.treat';
 export { default as usedStyle } from './used.treat';
+export { default as theme } from './theme.treat';
+export { default as unusedTheme } from './unusedTheme.treat';

--- a/packages/treat/tests/fixtures/unused-modules/unusedTheme.treat.ts
+++ b/packages/treat/tests/fixtures/unused-modules/unusedTheme.treat.ts
@@ -1,0 +1,3 @@
+import { createTheme } from 'treat';
+
+export default createTheme({ name: 'unused-theme' });

--- a/packages/treat/tests/fixtures/unused-modules/usedThemeStyle.treat.ts
+++ b/packages/treat/tests/fixtures/unused-modules/usedThemeStyle.treat.ts
@@ -1,0 +1,6 @@
+import { style } from 'treat';
+
+export default style(() => ({
+  top: 100,
+  bottom: 100,
+}));

--- a/packages/treat/webpack-plugin/plugin.js
+++ b/packages/treat/webpack-plugin/plugin.js
@@ -180,8 +180,24 @@ module.exports = class TreatWebpackPlugin {
           // Some modules may not be used and their css can be safely be removed from the chunks
           const [usedCssModules, modulesToRemove] = partition(
             allCssModules,
-            ({ owner }) =>
-              typeof owner.used === 'boolean' ? owner.used : true,
+            ({ identifier, owner, themeModule }) => {
+              const used = m => (typeof m.used === 'boolean' ? m.used : true);
+
+              const ownerIsUsed = used(owner);
+              const themeIsUsed = !themeModule || used(themeModule);
+
+              const cssModuleIsUsed = ownerIsUsed && themeIsUsed;
+
+              if (!cssModuleIsUsed) {
+                this.trace(
+                  'CSS Module marked for removal due to unused',
+                  chalk.yellow(ownerIsUsed ? 'theme' : 'owner'),
+                  debugIdent(identifier),
+                );
+              }
+
+              return cssModuleIsUsed;
+            },
           );
 
           if (modulesToRemove.length > 0) {


### PR DESCRIPTION
This fix allows entire themes to be tree shaken correctly. Previously, treat would error when theme modules were marked as unused.