### PR TITLE
docs: Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ import { style } from 'treat';
 export const button = style({
   backgroundColor: 'blue',
   height: 48
-}));
+});
 ```
 
 Finally, import the styles.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -21,7 +21,7 @@ import { style } from 'treat';
 export const button = style({
   backgroundColor: 'blue',
   height: 48
-}));
+});
 ```
 
 When treat files are executed at build time, all of the exports are inlined into your bundle. For example, the treat file above would turn into this:


### PR DESCRIPTION
Awesome work to everyone involved making this package - it's great 👍I was reading through the docs and noticed some really small typos in a couple of the code examples.