### PR TITLE
fix: Handle zeroes in treat class selectors

### DIFF
--- a/packages/treat/src/processSelectors.test.ts
+++ b/packages/treat/src/processSelectors.test.ts
@@ -7,6 +7,7 @@ describe('combinedThemeSelector', () => {
       ['html', 'html'],
       ['html .someClass', 'html .someClass'],
       ['$themedClass *', '.themedClass_singleTheme *'],
+      ['$themedClass_aZ-90 *', '.themedClass_aZ-90_singleTheme *'],
       [
         '$themedClass .someClass, h1',
         '.themedClass_singleTheme .someClass, h1',

--- a/packages/treat/src/processSelectors.ts
+++ b/packages/treat/src/processSelectors.ts
@@ -33,7 +33,7 @@ export const interpolateSelector = (selector: string, themeRef?: ThemeRef) => {
   }
 
   const themeClassRefsRegex = RegExp(
-    `\\${themePlaceholder}([a-zA-Z1-9_-]+)`,
+    `\\${themePlaceholder}([a-zA-Z0-9_-]+)`,
     'g',
   );
 


### PR DESCRIPTION
A treat class may be suffixed with a content hash containing a zero:

```text
delectableSelectable_eNAy0
```

This wasn't being parsed correctly in selectors:

```js
[`${delectableSelectable} &`]
```

```css
.BRAID__Component-delectableSelectable_eNAy_seekAnz0
.BRAID__Component-anotherClass {}
```