### PR TITLE
fix: Produce single type definitions

### DIFF
--- a/packages/react-treat/.npmignore
+++ b/packages/react-treat/.npmignore
@@ -2,3 +2,4 @@ node_modules
 src
 tests
 tsconfig.json
+*.tsbuildinfo

--- a/packages/react-treat/package.json
+++ b/packages/react-treat/package.json
@@ -4,14 +4,16 @@
   "version": "1.1.6",
   "main": "lib/commonjs",
   "module": "lib/module",
+  "types": "lib/types",
   "sideEffects": false,
   "author": "SEEK",
   "license": "MIT",
   "repository": "https://github.com/seek-oss/treat/tree/master/packages/react-treat",
   "scripts": {
-    "build:module": "tsc --module es2015 --outDir lib/module",
-    "build:commonjs": "tsc --module commonjs --outDir lib/commonjs",
-    "build": "concurrently \"yarn build:module\" \"yarn build:commonjs\"",
+    "build:module": "tsc --module es2015 --outDir lib/module --declaration false",
+    "build:commonjs": "tsc --module commonjs --outDir lib/commonjs --declaration false",
+    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir lib/types",
+    "build": "concurrently \"yarn:build:module\" \"yarn:build:commonjs\" \"yarn:build:types\"",
     "watch": "concurrently \"tsc --module commonjs --watch\" \"tsc --module module --watch\""
   },
   "keywords": [

--- a/packages/react-treat/package.json
+++ b/packages/react-treat/package.json
@@ -14,7 +14,7 @@
     "build:commonjs": "tsc --module commonjs --outDir lib/commonjs --declaration false",
     "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir lib/types",
     "build": "concurrently \"yarn:build:module\" \"yarn:build:commonjs\" \"yarn:build:types\"",
-    "watch": "concurrently \"tsc --module commonjs --watch\" \"tsc --module module --watch\""
+    "watch": "concurrently \"tsc --module commonjs --watch\" \"tsc --module module --watch\" \"yarn:build:types --watch\""
   },
   "keywords": [
     "treat"

--- a/packages/react-treat/package.json
+++ b/packages/react-treat/package.json
@@ -13,8 +13,7 @@
     "build:module": "tsc --module es2015 --outDir lib/module --declaration false",
     "build:commonjs": "tsc --module commonjs --outDir lib/commonjs --declaration false",
     "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir lib/types",
-    "build": "concurrently \"yarn:build:module\" \"yarn:build:commonjs\" \"yarn:build:types\"",
-    "watch": "concurrently \"tsc --module commonjs --watch\" \"tsc --module module --watch\" \"yarn:build:types --watch\""
+    "build": "concurrently \"yarn:build:module\" \"yarn:build:commonjs\" \"yarn:build:types\""
   },
   "keywords": [
     "treat"

--- a/packages/treat/.npmignore
+++ b/packages/treat/.npmignore
@@ -2,3 +2,4 @@ node_modules
 src
 tests
 tsconfig.json
+*.tsbuildinfo

--- a/packages/treat/package.json
+++ b/packages/treat/package.json
@@ -12,7 +12,7 @@
     "build:commonjs": "tsc --module commonjs --outDir lib/commonjs --declaration false",
     "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir lib/types",
     "build": "concurrently \"yarn:build:module\" \"yarn:build:commonjs\" \"yarn:build:types\"",
-    "watch": "concurrently \"tsc --module commonjs --watch\" \"tsc --module module --watch\""
+    "watch": "concurrently \"tsc --module commonjs --watch\" \"tsc --module module --watch\" \"yarn:build:types --watch\""
   },
   "author": "SEEK",
   "license": "MIT",

--- a/packages/treat/package.json
+++ b/packages/treat/package.json
@@ -11,8 +11,7 @@
     "build:module": "tsc --module es2015 --outDir lib/module --declaration false",
     "build:commonjs": "tsc --module commonjs --outDir lib/commonjs --declaration false",
     "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir lib/types",
-    "build": "concurrently \"yarn:build:module\" \"yarn:build:commonjs\" \"yarn:build:types\"",
-    "watch": "concurrently \"tsc --module commonjs --watch\" \"tsc --module module --watch\" \"yarn:build:types --watch\""
+    "build": "concurrently \"yarn:build:module\" \"yarn:build:commonjs\" \"yarn:build:types\""
   },
   "author": "SEEK",
   "license": "MIT",

--- a/packages/treat/package.json
+++ b/packages/treat/package.json
@@ -5,11 +5,13 @@
   "main": "lib/commonjs",
   "module": "lib/module",
   "browser": "lib/module/browser",
+  "types": "lib/types",
   "sideEffects": false,
   "scripts": {
-    "build:module": "tsc --module es2015 --outDir lib/module",
-    "build:commonjs": "tsc --module commonjs --outDir lib/commonjs",
-    "build": "concurrently \"yarn build:module\" \"yarn build:commonjs\"",
+    "build:module": "tsc --module es2015 --outDir lib/module --declaration false",
+    "build:commonjs": "tsc --module commonjs --outDir lib/commonjs --declaration false",
+    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir lib/types",
+    "build": "concurrently \"yarn:build:module\" \"yarn:build:commonjs\" \"yarn:build:types\"",
     "watch": "concurrently \"tsc --module commonjs --watch\" \"tsc --module module --watch\""
   },
   "author": "SEEK",


### PR DESCRIPTION
With this PR I aim to address the problem with multiple types in the artifact, and Jetbrains users in that, auto-import's don't resolve to `"treat"` but rather gives you the option to pick `"treat/lib/{commonjs,module}"`.

<img width="565" alt="image" src="https://user-images.githubusercontent.com/599459/68169655-b9eea180-ffb8-11e9-93e8-3e1f6ad9c856.png">
