### PR TITLE
fix(styleMap): Support numbers as keys on 'styleMap' objects

### DIFF
--- a/packages/treat/src/builder.ts
+++ b/packages/treat/src/builder.ts
@@ -159,14 +159,14 @@ export function style(
   }
 }
 
-type StyleMapParam<ClassName extends string> = ThemedStyle<
-  StyleMap<ClassName, Style>,
+type StyleMapParam<StyleName extends string | number> = ThemedStyle<
+  StyleMap<StyleName, Style>,
   ThemeOrAny
 >;
-export function styleMap<ClassName extends string>(
-  stylesheet: StyleMapParam<ClassName>,
+export function styleMap<StyleName extends string | number>(
+  stylesheet: StyleMapParam<StyleName>,
   localDebugName?: string,
-): StylesMap<ClassName> {
+): StylesMap<StyleName> {
   const classRefs: { [className: string]: ClassRef } = {};
   const createLocalName = (classIdentifier: string) => {
     if (localDebugName) {

--- a/packages/treat/src/types.ts
+++ b/packages/treat/src/types.ts
@@ -38,8 +38,8 @@ export type Style = StyleWithSelectors & MediaQueries<StyleWithSelectors>;
 
 export type GlobalStyle = CSSProperties & MediaQueries<CSSProperties>;
 
-export type StyleMap<ClassName extends string, StyleType> = Record<
-  ClassName,
+export type StyleMap<StyleName extends string | number, StyleType> = Record<
+  StyleName,
   StyleType
 >;
 
@@ -54,7 +54,10 @@ export interface TreatTheme<Tokens> {
 
 export type ClassRef = string;
 
-export type StylesMap<ClassName extends string> = Record<ClassName, ClassRef>;
+export type StylesMap<StyleName extends string | number> = Record<
+  StyleName,
+  ClassRef
+>;
 
 type TreatModuleValue =
   | string


### PR DESCRIPTION
Currently, numbers are not supported as keys of `styleMap` from a type perspective. For example, `styleMap({ 0: { ... } })` returns a type of `Record<string, string>` rather than `Record<0, string>`.

This PR fixes it by allowing style map keys to extend numbers as well as strings.