### PR TITLE
feat(gatsby-plugin-treat): Theme shadowing

### DIFF
--- a/packages/gatsby-plugin-treat/README.md
+++ b/packages/gatsby-plugin-treat/README.md
@@ -10,6 +10,21 @@ module.exports = {
 };
 ```
 
+## Theming
+
+The default theme can be customized by shadowing the file at `src/gatsby-plugin-treat/theme.treat.js`, e.g. with:
+
+```ts
+import { createTheme } from 'treat';
+
+export default createTheme({
+  colors: {
+    red: '#f8485e',
+    darkgray: '#3d3d3d'
+  }
+});
+```
+
 ## [Docs](https://seek-oss.github.io/treat)
 
 See the documentation at seek-oss.github.io/treat for more information about using treat.

--- a/packages/gatsby-plugin-treat/gatsby-browser.js
+++ b/packages/gatsby-plugin-treat/gatsby-browser.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { ThemeProvider } from 'react-treat';
+
+import theme from './src/theme.treat';
+
+export const wrapRootElement = ({ element }) => (
+  <ThemeProvider theme={theme}>{element}</ThemeProvider>
+);

--- a/packages/gatsby-plugin-treat/gatsby-ssr.js
+++ b/packages/gatsby-plugin-treat/gatsby-ssr.js
@@ -1,0 +1,1 @@
+export { wrapRootElement } from './gatsby-browser';

--- a/packages/gatsby-plugin-treat/src/theme.treat.js
+++ b/packages/gatsby-plugin-treat/src/theme.treat.js
@@ -1,0 +1,3 @@
+import { createTheme } from 'treat';
+
+export default createTheme({});


### PR DESCRIPTION
This allows setting up `gatsby-plugin-treat` without wrapping components in a top-level `<ThemeProvider>` manually. For instance, the empty default theme could be overridden through `src/gatsby-plugin-treat/theme.treat.ts` as follows:

```ts
import { createTheme } from 'treat';

export default createTheme({
  colors: {
    red: '#f8485e',
    darkgray: '#3d3d3d'
  }
});
```

The implementation was inspired by [gatsby-plugin-chakra-ui](https://github.com/chakra-ui/chakra-ui/tree/master/packages/gatsby-plugin-chakra-ui) and [gatsby-plugin-theme-ui](https://github.com/system-ui/theme-ui/tree/master/packages/gatsby-plugin-theme-ui).