### PR TITLE
fix(webpack-plugin): Checking treat file extension

### DIFF
--- a/packages/treat/webpack-plugin/plugin.js
+++ b/packages/treat/webpack-plugin/plugin.js
@@ -32,7 +32,7 @@ module.exports = class TreatWebpackPlugin {
     optionValidator(options);
 
     const {
-      test = /\.treat.(js|ts)$/,
+      test = /\.treat\.(js|ts)$/,
       outputCSS = true,
       outputLoaders = ['style-loader'],
       localIdentName,


### PR DESCRIPTION
The previous code accepted filenames like `*.treatXjs` or `*.treat_ts`.