### PR TITLE
fix(gatsby-plugin): Idiomatic SSR setup

### DIFF
--- a/packages/gatsby-plugin-treat/gatsby-node.js
+++ b/packages/gatsby-plugin-treat/gatsby-node.js
@@ -1,5 +1,4 @@
 const TreatPlugin = require('treat/webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 exports.onCreateBabelConfig = ({ actions }) => {
   actions.setBabelPlugin({
@@ -8,13 +7,12 @@ exports.onCreateBabelConfig = ({ actions }) => {
 };
 
 exports.onCreateWebpackConfig = (
-  { stage, actions },
+  { stage, loaders, actions },
   { plugins, ...pluginOptions },
 ) => {
   if (stage === 'develop-html') return;
 
-  const isDev = stage.includes('develop');
-  const defaultPluginOptions = isDev
+  const defaultPluginOptions = stage.includes('develop')
     ? {
         localIdentName: '[name]-[local]_[hash:base64:5]',
         themeIdentName: '_[name]-[local]_[hash:base64:4]',
@@ -30,12 +28,7 @@ exports.onCreateWebpackConfig = (
         ...defaultPluginOptions,
         ...pluginOptions,
         outputCSS: !stage.includes('html'),
-        outputLoaders: !isDev
-          ? [
-              // Logic adopted from https://github.com/gatsbyjs/gatsby/blob/7bc6af46e5bd4cdde76be3fa4a857e00fc2e4635/packages/gatsby/src/utils/webpack-utils.ts#L185-L193
-              MiniCssExtractPlugin.loader,
-            ]
-          : undefined,
+        outputLoaders: loaders.miniCssExtract(),
       }),
     ],
   });

--- a/packages/gatsby-plugin-treat/gatsby-node.js
+++ b/packages/gatsby-plugin-treat/gatsby-node.js
@@ -28,7 +28,7 @@ exports.onCreateWebpackConfig = (
         ...defaultPluginOptions,
         ...pluginOptions,
         outputCSS: !stage.includes('html'),
-        outputLoaders: loaders.miniCssExtract(),
+        outputLoaders: [loaders.miniCssExtract()],
       }),
     ],
   });

--- a/packages/gatsby-plugin-treat/package.json
+++ b/packages/gatsby-plugin-treat/package.json
@@ -14,8 +14,7 @@
     "treat": "^1.1.7"
   },
   "dependencies": {
-    "babel-plugin-treat": "^1.1.0",
-    "mini-css-extract-plugin": "^0.8.0"
+    "babel-plugin-treat": "^1.1.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This allows Gatsby to update the underlying `MiniCssExtractPlugin` on its own. The new implementation works [exactly as it did](https://github.com/gatsbyjs/gatsby/blob/1e59c65ed5117eba8f7fdc2f31d379c92383e474/packages/gatsby/src/utils/webpack-utils.ts#L185-L193) until now.