### PR TITLE
fix: Ensure consistent and valid content hashes

### DIFF
--- a/packages/treat/package.json
+++ b/packages/treat/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@hapi/joi": "^15.0.3",
+    "@types/object-hash": "^1.2.0",
     "autoprefixer": "^9.6.0",
     "bluebird": "^3.5.4",
     "chalk": "^2.4.2",
@@ -34,6 +35,7 @@
     "loader-utils": "^1.2.3",
     "lodash": "^4.17.11",
     "normalize-path": "^3.0.0",
+    "object-hash": "^2.0.3",
     "postcss": "^7.0.14",
     "postcss-js": "^2.0.0",
     "style-loader": "^0.23.1",

--- a/packages/treat/src/createContentHash.ts
+++ b/packages/treat/src/createContentHash.ts
@@ -1,10 +1,8 @@
-import crypto from 'crypto';
+import objectHash from 'object-hash';
 
 export const createContentHash = (content: any) => {
-  return crypto
-    .createHash('sha1')
-    .update(JSON.stringify(content))
-    .digest('base64')
+  return objectHash
+    .sha1(content)
     .slice(0, 5)
-    .replace(/^((-?[0-9])|--)/, '_$1');
+    .replace(/(^[0-9])/, '_$1');
 };

--- a/packages/treat/tests/__snapshots__/stylesheet.test.ts.snap
+++ b/packages/treat/tests/__snapshots__/stylesheet.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Stylesheet Animations - Autoprefixer (iOS 8) - should create a deterministic stylesheet 1`] = `
-"@-webkit-keyframes Xxm1J {
+"@-webkit-keyframes _0afb7 {
     from {
         opacity: 0
     }
@@ -9,7 +9,7 @@ exports[`Stylesheet Animations - Autoprefixer (iOS 8) - should create a determin
         opacity: 1
     }
 }
-@keyframes Xxm1J {
+@keyframes _0afb7 {
     from {
         opacity: 0
     }
@@ -17,7 +17,7 @@ exports[`Stylesheet Animations - Autoprefixer (iOS 8) - should create a determin
         opacity: 1
     }
 }
-@-webkit-keyframes Yuc9Q {
+@-webkit-keyframes _92d6d {
     from {
         color: rgba(255,255,255,0);
         -webkit-transform: scale(1);
@@ -41,7 +41,7 @@ exports[`Stylesheet Animations - Autoprefixer (iOS 8) - should create a determin
         color: rgba(255,255,255,1)
     }
 }
-@keyframes Yuc9Q {
+@keyframes _92d6d {
     from {
         color: rgba(255,255,255,0);
         -webkit-transform: scale(1);
@@ -65,7 +65,7 @@ exports[`Stylesheet Animations - Autoprefixer (iOS 8) - should create a determin
         color: rgba(255,255,255,1)
     }
 }
-@-webkit-keyframes ULbBx {
+@-webkit-keyframes _78cfa {
     from {
         -webkit-transform: rotate(0deg);
                 transform: rotate(0deg)
@@ -75,7 +75,7 @@ exports[`Stylesheet Animations - Autoprefixer (iOS 8) - should create a determin
                 transform: rotate(359deg)
     }
 }
-@keyframes ULbBx {
+@keyframes _78cfa {
     from {
         -webkit-transform: rotate(0deg);
                 transform: rotate(0deg)
@@ -103,13 +103,13 @@ exports[`Stylesheet Animations - Autoprefixer (iOS 8) - should create a determin
             animation-duration: 3s;
     -webkit-animation-fill-mode: both;
             animation-fill-mode: both;
-    -webkit-animation-name: Xxm1J;
-            animation-name: Xxm1J
+    -webkit-animation-name: _0afb7;
+            animation-name: _0afb7
 }
 @media (min-width: 700px) {
     ._1aUDE:hover {
-        -webkit-animation: Yuc9Q 1.5s ease-out forwards;
-                animation: Yuc9Q 1.5s ease-out forwards
+        -webkit-animation: _92d6d 1.5s ease-out forwards;
+                animation: _92d6d 1.5s ease-out forwards
     }
 }
 @media (max-width: 699px) {
@@ -120,45 +120,11 @@ exports[`Stylesheet Animations - Autoprefixer (iOS 8) - should create a determin
                 animation-duration: 1.5s;
         -webkit-animation-iteration-count: infinite;
                 animation-iteration-count: infinite;
-        -webkit-animation-name: ULbBx;
-                animation-name: ULbBx
+        -webkit-animation-name: _78cfa;
+                animation-name: _78cfa
     }
 }
-@-webkit-keyframes _0Mv05 {
-    from {
-        background-color: white
-    }
-    to {
-        background-color: red
-    }
-}
-@keyframes _0Mv05 {
-    from {
-        background-color: white
-    }
-    to {
-        background-color: red
-    }
-}
-.tjufO_3XPt {
-    height: 200px;
-    width: 200px
-}
-._1aUDE ~ .tjufO_3XPt {
-    -webkit-animation-timing-function: linear;
-            animation-timing-function: linear;
-    -webkit-animation-duration: 1s;
-            animation-duration: 1s;
-    -webkit-animation-direction: alternate;
-            animation-direction: alternate;
-    -webkit-animation-fill-mode: both;
-            animation-fill-mode: both;
-    -webkit-animation-iteration-count: infinite;
-            animation-iteration-count: infinite;
-    -webkit-animation-name: _0Mv05;
-            animation-name: _0Mv05
-}
-@-webkit-keyframes _3W3VQ {
+@-webkit-keyframes b0ae1 {
     from {
         background-color: white
     }
@@ -166,7 +132,7 @@ exports[`Stylesheet Animations - Autoprefixer (iOS 8) - should create a determin
         background-color: blue
     }
 }
-@keyframes _3W3VQ {
+@keyframes b0ae1 {
     from {
         background-color: white
     }
@@ -189,14 +155,48 @@ exports[`Stylesheet Animations - Autoprefixer (iOS 8) - should create a determin
             animation-fill-mode: both;
     -webkit-animation-iteration-count: infinite;
             animation-iteration-count: infinite;
-    -webkit-animation-name: _3W3VQ;
-            animation-name: _3W3VQ
+    -webkit-animation-name: b0ae1;
+            animation-name: b0ae1
+}
+@-webkit-keyframes _9dba8 {
+    from {
+        background-color: white
+    }
+    to {
+        background-color: red
+    }
+}
+@keyframes _9dba8 {
+    from {
+        background-color: white
+    }
+    to {
+        background-color: red
+    }
+}
+.tjufO_3XPt {
+    height: 200px;
+    width: 200px
+}
+._1aUDE ~ .tjufO_3XPt {
+    -webkit-animation-timing-function: linear;
+            animation-timing-function: linear;
+    -webkit-animation-duration: 1s;
+            animation-duration: 1s;
+    -webkit-animation-direction: alternate;
+            animation-direction: alternate;
+    -webkit-animation-fill-mode: both;
+            animation-fill-mode: both;
+    -webkit-animation-iteration-count: infinite;
+            animation-iteration-count: infinite;
+    -webkit-animation-name: _9dba8;
+            animation-name: _9dba8
 }
 "
 `;
 
 exports[`Stylesheet Animations - Custom idents - should create a deterministic stylesheet 1`] = `
-"@keyframes Xxm1J {
+"@keyframes _0afb7 {
     from {
         opacity: 0
     }
@@ -204,7 +204,7 @@ exports[`Stylesheet Animations - Custom idents - should create a deterministic s
         opacity: 1
     }
 }
-@keyframes Yuc9Q {
+@keyframes _92d6d {
     from {
         color: rgba(255,255,255,0);
         transform: scale(1)
@@ -223,7 +223,7 @@ exports[`Stylesheet Animations - Custom idents - should create a deterministic s
         color: rgba(255,255,255,1)
     }
 }
-@keyframes ULbBx {
+@keyframes _78cfa {
     from {
         transform: rotate(0deg)
     }
@@ -243,11 +243,11 @@ exports[`Stylesheet Animations - Custom idents - should create a deterministic s
     animation-timing-function: linear;
     animation-duration: 3s;
     animation-fill-mode: both;
-    animation-name: Xxm1J
+    animation-name: _0afb7
 }
 @media (min-width: 700px) {
     .animations-unthemedAnimation_1aUDE:hover {
-        animation: Yuc9Q 1.5s ease-out forwards
+        animation: _92d6d 1.5s ease-out forwards
     }
 }
 @media (max-width: 699px) {
@@ -255,10 +255,10 @@ exports[`Stylesheet Animations - Custom idents - should create a deterministic s
         animation-timing-function: linear;
         animation-duration: 1.5s;
         animation-iteration-count: infinite;
-        animation-name: ULbBx
+        animation-name: _78cfa
     }
 }
-@keyframes _0Mv05 {
+@keyframes _9dba8 {
     from {
         background-color: white
     }
@@ -276,9 +276,9 @@ exports[`Stylesheet Animations - Custom idents - should create a deterministic s
     animation-direction: alternate;
     animation-fill-mode: both;
     animation-iteration-count: infinite;
-    animation-name: _0Mv05
+    animation-name: _9dba8
 }
-@keyframes _3W3VQ {
+@keyframes b0ae1 {
     from {
         background-color: white
     }
@@ -296,13 +296,13 @@ exports[`Stylesheet Animations - Custom idents - should create a deterministic s
     animation-direction: alternate;
     animation-fill-mode: both;
     animation-iteration-count: infinite;
-    animation-name: _3W3VQ
+    animation-name: b0ae1
 }
 "
 `;
 
 exports[`Stylesheet Animations - Development mode - should create a deterministic stylesheet 1`] = `
-"@keyframes Xxm1J {
+"@keyframes _0afb7 {
     from {
         opacity: 0
     }
@@ -310,7 +310,7 @@ exports[`Stylesheet Animations - Development mode - should create a deterministi
         opacity: 1
     }
 }
-@keyframes Yuc9Q {
+@keyframes _92d6d {
     from {
         color: rgba(255,255,255,0);
         transform: scale(1)
@@ -329,7 +329,7 @@ exports[`Stylesheet Animations - Development mode - should create a deterministi
         color: rgba(255,255,255,1)
     }
 }
-@keyframes ULbBx {
+@keyframes _78cfa {
     from {
         transform: rotate(0deg)
     }
@@ -349,11 +349,11 @@ exports[`Stylesheet Animations - Development mode - should create a deterministi
     animation-timing-function: linear;
     animation-duration: 3s;
     animation-fill-mode: both;
-    animation-name: Xxm1J
+    animation-name: _0afb7
 }
 @media (min-width: 700px) {
     .animations-unthemedAnimation_1aUDE:hover {
-        animation: Yuc9Q 1.5s ease-out forwards
+        animation: _92d6d 1.5s ease-out forwards
     }
 }
 @media (max-width: 699px) {
@@ -361,10 +361,10 @@ exports[`Stylesheet Animations - Development mode - should create a deterministi
         animation-timing-function: linear;
         animation-duration: 1.5s;
         animation-iteration-count: infinite;
-        animation-name: ULbBx
+        animation-name: _78cfa
     }
 }
-@keyframes _3W3VQ {
+@keyframes b0ae1 {
     from {
         background-color: white
     }
@@ -382,9 +382,9 @@ exports[`Stylesheet Animations - Development mode - should create a deterministi
     animation-direction: alternate;
     animation-fill-mode: both;
     animation-iteration-count: infinite;
-    animation-name: _3W3VQ
+    animation-name: b0ae1
 }
-@keyframes _0Mv05 {
+@keyframes _9dba8 {
     from {
         background-color: white
     }
@@ -402,20 +402,20 @@ exports[`Stylesheet Animations - Development mode - should create a deterministi
     animation-direction: alternate;
     animation-fill-mode: both;
     animation-iteration-count: infinite;
-    animation-name: _0Mv05
+    animation-name: _9dba8
 }
 "
 `;
 
 exports[`Stylesheet Animations - Production mode - should create a deterministic stylesheet 1`] = `
-"@keyframes Xxm1J{0%{opacity:0}to{opacity:1}}@keyframes Yuc9Q{0%{color:hsla(0,0%,100%,0);transform:scale(1)}25%{transform:scale(2,3)}50%{transform:scale(5)}75%{transform:scale(4,.5)}to{transform:scale(1);color:#fff}}@keyframes ULbBx{0%{transform:rotate(0deg)}to{transform:rotate(359deg)}}._1aUDE{margin-left:300px;display:flex;justify-content:center;align-items:center;height:200px;width:200px;background-color:#ff0;color:hsla(0,0%,100%,0);animation-timing-function:linear;animation-duration:3s;animation-fill-mode:both;animation-name:Xxm1J}@media (min-width:700px){._1aUDE:hover{animation:Yuc9Q 1.5s ease-out forwards}}@media (max-width:699px){._1aUDE{animation-timing-function:linear;animation-duration:1.5s;animation-iteration-count:infinite;animation-name:ULbBx}}
-@keyframes _0Mv05{0%{background-color:#fff}to{background-color:red}}.tjufO_3XPt{height:200px;width:200px}._1aUDE~.tjufO_3XPt{animation-timing-function:linear;animation-duration:1s;animation-direction:alternate;animation-fill-mode:both;animation-iteration-count:infinite;animation-name:_0Mv05}
-@keyframes _3W3VQ{0%{background-color:#fff}to{background-color:#00f}}.tjufO_6Iw9{height:200px;width:200px}._1aUDE~.tjufO_6Iw9{animation-timing-function:linear;animation-duration:3s;animation-direction:alternate;animation-fill-mode:both;animation-iteration-count:infinite;animation-name:_3W3VQ}
+"@keyframes _0afb7{0%{opacity:0}to{opacity:1}}@keyframes _92d6d{0%{color:hsla(0,0%,100%,0);transform:scale(1)}25%{transform:scale(2,3)}50%{transform:scale(5)}75%{transform:scale(4,.5)}to{transform:scale(1);color:#fff}}@keyframes _78cfa{0%{transform:rotate(0deg)}to{transform:rotate(359deg)}}._1aUDE{margin-left:300px;display:flex;justify-content:center;align-items:center;height:200px;width:200px;background-color:#ff0;color:hsla(0,0%,100%,0);animation-timing-function:linear;animation-duration:3s;animation-fill-mode:both;animation-name:_0afb7}@media (min-width:700px){._1aUDE:hover{animation:_92d6d 1.5s ease-out forwards}}@media (max-width:699px){._1aUDE{animation-timing-function:linear;animation-duration:1.5s;animation-iteration-count:infinite;animation-name:_78cfa}}
+@keyframes b0ae1{0%{background-color:#fff}to{background-color:#00f}}.tjufO_6Iw9{height:200px;width:200px}._1aUDE~.tjufO_6Iw9{animation-timing-function:linear;animation-duration:3s;animation-direction:alternate;animation-fill-mode:both;animation-iteration-count:infinite;animation-name:b0ae1}
+@keyframes _9dba8{0%{background-color:#fff}to{background-color:red}}.tjufO_3XPt{height:200px;width:200px}._1aUDE~.tjufO_3XPt{animation-timing-function:linear;animation-duration:1s;animation-direction:alternate;animation-fill-mode:both;animation-iteration-count:infinite;animation-name:_9dba8}
 "
 `;
 
 exports[`Stylesheet Animations - Theme function ident - should create a deterministic stylesheet 1`] = `
-"@keyframes Xxm1J {
+"@keyframes _0afb7 {
     from {
         opacity: 0
     }
@@ -423,7 +423,7 @@ exports[`Stylesheet Animations - Theme function ident - should create a determin
         opacity: 1
     }
 }
-@keyframes Yuc9Q {
+@keyframes _92d6d {
     from {
         color: rgba(255,255,255,0);
         transform: scale(1)
@@ -442,7 +442,7 @@ exports[`Stylesheet Animations - Theme function ident - should create a determin
         color: rgba(255,255,255,1)
     }
 }
-@keyframes ULbBx {
+@keyframes _78cfa {
     from {
         transform: rotate(0deg)
     }
@@ -462,11 +462,11 @@ exports[`Stylesheet Animations - Theme function ident - should create a determin
     animation-timing-function: linear;
     animation-duration: 3s;
     animation-fill-mode: both;
-    animation-name: Xxm1J
+    animation-name: _0afb7
 }
 @media (min-width: 700px) {
     ._1aUDE:hover {
-        animation: Yuc9Q 1.5s ease-out forwards
+        animation: _92d6d 1.5s ease-out forwards
     }
 }
 @media (max-width: 699px) {
@@ -474,30 +474,10 @@ exports[`Stylesheet Animations - Theme function ident - should create a determin
         animation-timing-function: linear;
         animation-duration: 1.5s;
         animation-iteration-count: infinite;
-        animation-name: ULbBx
+        animation-name: _78cfa
     }
 }
-@keyframes _0Mv05 {
-    from {
-        background-color: white
-    }
-    to {
-        background-color: red
-    }
-}
-.tjufO_fast_3X {
-    height: 200px;
-    width: 200px
-}
-._1aUDE ~ .tjufO_fast_3X {
-    animation-timing-function: linear;
-    animation-duration: 1s;
-    animation-direction: alternate;
-    animation-fill-mode: both;
-    animation-iteration-count: infinite;
-    animation-name: _0Mv05
-}
-@keyframes _3W3VQ {
+@keyframes b0ae1 {
     from {
         background-color: white
     }
@@ -515,7 +495,27 @@ exports[`Stylesheet Animations - Theme function ident - should create a determin
     animation-direction: alternate;
     animation-fill-mode: both;
     animation-iteration-count: infinite;
-    animation-name: _3W3VQ
+    animation-name: b0ae1
+}
+@keyframes _9dba8 {
+    from {
+        background-color: white
+    }
+    to {
+        background-color: red
+    }
+}
+.tjufO_fast_3X {
+    height: 200px;
+    width: 200px
+}
+._1aUDE ~ .tjufO_fast_3X {
+    animation-timing-function: linear;
+    animation-duration: 1s;
+    animation-direction: alternate;
+    animation-fill-mode: both;
+    animation-iteration-count: infinite;
+    animation-name: _9dba8
 }
 "
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,6 +3470,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/object-hash@^1.2.0":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-1.3.1.tgz#b8145122b230bad5a13cba52016e78c54dae6ed5"
+  integrity sha512-xhLwbVGAXi/LJEowMjRY1anbF5sQWeuocVjaMrFYy4bOEpl79A4eIby3xlowbkXytUdbISwOZB+vQx9Y/n0p8A==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -13068,6 +13073,11 @@ object-hash@^1.1.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
+
+object-hash@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.0.3.tgz#d12db044e03cd2ca3d77c0570d87225b02e1e6ea"
+  integrity sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg==
 
 object-inspect@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
Treat currently generates both inconsistent and invalid references for 'keyframe' objects. 

The current implementation for createContentHash() uses JSON.stringify() which means that the resulting hash will be inconsistent as key ordering will affect the serialized value. The Base64 encoded digest can also contain characters which are invalid in CSS identifiers without appropriate escaping e.g. '/'.

This fix uses the 'object-hash' library to generate consistent and valid hashes for use as references.