### PR TITLE
feat: Add's klona for safer cloning of objects

### DIFF
--- a/packages/treat/package.json
+++ b/packages/treat/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@hapi/joi": "^15.0.3",
     "@types/object-hash": "^1.2.0",
+    "klona": "^1.1.2",
     "autoprefixer": "^9.6.0",
     "bluebird": "^3.5.4",
     "chalk": "^2.4.2",

--- a/packages/treat/src/resolveStyles.ts
+++ b/packages/treat/src/resolveStyles.ts
@@ -1,3 +1,4 @@
+import klona from 'klona';
 import { resolveClassName } from './resolveClassName';
 import { ThemeRef, TreatModule } from './types';
 
@@ -31,7 +32,7 @@ const walkTreatModule = <UserStyles extends TreatModule>(
   themeRef: ThemeRef,
   styles: UserStyles,
 ): UserStyles => {
-  const clone = styles.constructor();
+  const clone = klona(styles);
 
   for (let key in styles) {
     const value = styles[key];

--- a/yarn.lock
+++ b/yarn.lock
@@ -11431,6 +11431,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+klona@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/klona/-/klona-1.1.2.tgz#a79e292518a5a5412ec8d097964bff1571a64db0"
+  integrity sha512-xf88rTeHiXk+XE2Vhi6yj8Wm3gMZrygGdKjJqN8HkV+PwF/t50/LdAKHoHpPcxFAlmQszTZ1CugrK25S7qDRLA==
+
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz#9742df0e10e3cf46e5c0381c2de90d3a7a2d7555"


### PR DESCRIPTION
With bundlers like Rollup that emit frozen prototype free named exports, the convention `import * as styleRefs` wont work with the current runtime.

This is because the "object" being passed in is a `Object.assign(Object.create(null), { myClass: 'abc-123'})` equivalent, and thus has no `.constructor` method.

This doesn't just solve Rollup, but anyone who passed in an object without a constructor.

Because of this I'm proposing we add in [Klona](https://github.com/lukeed/klona/) a 366B safe cloning library. But im open to discussions here, seeing as we roughly know it'll only ever be objects to arrays of strings or just strings, we could probably trim that even further, localize it and remove the dependency.

*References*:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor
- https://github.com/lukeed/klona/
- [example of a rollup produced module](https://github.com/rollup/rollup/blob/aecd3e16c5d0f19feab75dabfbd4d86e5ccb4cee/test/chunking-form/samples/mixed-synthetic-named-exports/_expected/amd/main.js#L9-L12)