### PR TITLE
fix: Identifiers need to be stricter

### DIFF
--- a/packages/treat/src/createContentHash.ts
+++ b/packages/treat/src/createContentHash.ts
@@ -5,6 +5,9 @@ export const createContentHash = (content: any) => {
     .createHash('sha1')
     .update(JSON.stringify(content))
     .digest('base64')
+    // identifiers cannot start with double-dashes or numbers. Also if the first
+    // char is a hyphen and the 2nd isnt a letter or underscore, then replace
+    .replace(/^(((?:-{2,})?[0-9])|-[^a-z_])/i, '_$1')
+    .replace(/\+/g, '') // removes all +'s
     .slice(0, 5)
-    .replace(/^((-?[0-9])|--)/, '_$1');
 };


### PR DESCRIPTION
This issue aims to solve some of the animation-name, name restrictions outlined in the [mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-name). Granted this is a _global_ change and affects all identifiers, but believe it to be a good change none the less.

Further readings: 
- https://stackoverflow.com/a/449000/2609301
- https://developer.mozilla.org/en-US/docs/Web/CSS/animation-name

fixes: https://github.com/seek-oss/treat/issues/121