### PR TITLE
feat: Add @supports support

### DIFF
--- a/packages/treat/src/transformCSS.test.ts
+++ b/packages/treat/src/transformCSS.test.ts
@@ -225,32 +225,6 @@ describe('transformCSS', () => {
     `);
   });
 
-  it('should handle @supports queries', () => {
-    expect(
-      transformCSS({
-        '.testClass': {
-          display: 'flex',
-          '@supports': {
-            '(display: grid)': {
-              display: 'grid',
-            },
-          },
-        },
-      }),
-    ).toMatchInlineSnapshot(`
-      Object {
-        ".testClass": Object {
-          "display": "flex",
-        },
-        "@supports (display: grid)": Object {
-          ".testClass": Object {
-            "display": "grid",
-          },
-        },
-      }
-    `);
-  });
-
   it('should handle @supports negation queries', () => {
     expect(
       transformCSS({

--- a/packages/treat/src/transformCSS.test.ts
+++ b/packages/treat/src/transformCSS.test.ts
@@ -198,4 +198,82 @@ describe('transformCSS', () => {
                         }
                 `);
   });
+
+  it('should handle @supports queries', () => {
+    expect(
+      transformCSS({
+        '.testClass': {
+          display: 'flex',
+          '@supports': {
+            '(display: grid)': {
+              display: 'grid',
+            },
+          },
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      Object {
+        ".testClass": Object {
+          "display": "flex",
+        },
+        "@supports (display: grid)": Object {
+          ".testClass": Object {
+            "display": "grid",
+          },
+        },
+      }
+    `);
+  });
+
+  it('should handle @supports queries', () => {
+    expect(
+      transformCSS({
+        '.testClass': {
+          display: 'flex',
+          '@supports': {
+            '(display: grid)': {
+              display: 'grid',
+            },
+          },
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      Object {
+        ".testClass": Object {
+          "display": "flex",
+        },
+        "@supports (display: grid)": Object {
+          ".testClass": Object {
+            "display": "grid",
+          },
+        },
+      }
+    `);
+  });
+
+  it('should handle @supports negation queries', () => {
+    expect(
+      transformCSS({
+        '.testClass': {
+          display: 'grid',
+          '@supports': {
+            'not (display: grid)': {
+              display: 'flex',
+            },
+          },
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      Object {
+        ".testClass": Object {
+          "display": "grid",
+        },
+        "@supports not (display: grid)": Object {
+          ".testClass": Object {
+            "display": "flex",
+          },
+        },
+      }
+    `);
+  });
 });

--- a/packages/treat/src/transformCSS.ts
+++ b/packages/treat/src/transformCSS.ts
@@ -102,7 +102,7 @@ export type SimplePseudos = typeof simplePseudos;
 const simplePseudoSet = new Set<string>(simplePseudos);
 
 const normalizeStyles = (className: string, styles: any) => {
-  const omitThese = [...simplePseudos, '@media', 'selectors'];
+  const omitThese = [...simplePseudos, '@media', '@supports', 'selectors'];
 
   const pseudoStyles = mapKeys(
     pickBy(styles, (_, key) => simplePseudoSet.has(key)),
@@ -167,6 +167,18 @@ export default (styles: any) => {
         if (!isEqual(defaultStyles, blockStyles)) {
           merge(responsiveStyles, {
             [`@media ${query}`]: blockStyles,
+          });
+        }
+      });
+    }
+
+    if (styles['@supports']) {
+      each(styles['@supports'], (mediaStyles, query) => {
+        const blockStyles = normalizeStyles(className, mediaStyles);
+
+        if (!isEqual(defaultStyles, blockStyles)) {
+          merge(responsiveStyles, {
+            [`@supports ${query}`]: blockStyles,
           });
         }
       });

--- a/packages/treat/src/types.ts
+++ b/packages/treat/src/types.ts
@@ -30,13 +30,23 @@ export interface MediaQueries<StyleType> {
   };
 }
 
+export interface FeatureQueries<StyleType> {
+  '@supports'?: {
+    [query: string]: StyleType;
+  };
+}
+
 export interface StyleWithSelectors extends CSSPropertiesAndPseudos {
   selectors?: SelectorMap;
 }
 
-export type Style = StyleWithSelectors & MediaQueries<StyleWithSelectors>;
+export type Style = StyleWithSelectors &
+  MediaQueries<StyleWithSelectors> &
+  FeatureQueries<StyleWithSelectors>;
 
-export type GlobalStyle = CSSProperties & MediaQueries<CSSProperties>;
+export type GlobalStyle = CSSProperties &
+  MediaQueries<CSSProperties> &
+  FeatureQueries<CSSProperties>;
 
 export type StyleMap<StyleName extends string | number, StyleType> = Record<
   StyleName,

--- a/packages/treat/src/validator.test.js
+++ b/packages/treat/src/validator.test.js
@@ -36,6 +36,13 @@ describe('validator', () => {
           },
         },
       },
+      {
+        '@supports': {
+          '(display: grid)': {
+            display: 'flex',
+          },
+        },
+      },
     ];
 
     it.each(validTests)('valid', value => {
@@ -160,6 +167,17 @@ describe('validator', () => {
                     transform: 'scale(1)',
                   },
                 },
+              },
+            },
+          },
+        },
+      },
+      {
+        '@supports': {
+          '(display: grid)': {
+            selectors: {
+              ['.someClass &']: {
+                display: 'grid',
               },
             },
           },

--- a/packages/treat/src/validator.ts
+++ b/packages/treat/src/validator.ts
@@ -27,9 +27,13 @@ const fullStyle = cssWithSimplePseudos.append({
 });
 
 const makeMediaQuerySchema = (valueSchema: ObjectSchema) =>
-  valueSchema.append({
-    '@media': joi.object().pattern(joi.string(), valueSchema),
-  });
+  valueSchema
+    .append({
+      '@media': joi.object().pattern(joi.string(), valueSchema),
+    })
+    .append({
+      '@supports': joi.object().pattern(joi.string(), valueSchema),
+    });
 
 const fullStyleWithMedia = makeMediaQuerySchema(fullStyle).required();
 

--- a/packages/treat/src/validator.ts
+++ b/packages/treat/src/validator.ts
@@ -14,7 +14,7 @@ const cssWithKeyframesSchema = cssPropertiesSchema.append({
 const cssWithSimplePseudos = cssWithKeyframesSchema.append(
   Object.assign(
     {},
-    ...simplePseudos.map(pseudo => ({ [pseudo]: cssWithKeyframesSchema })),
+    ...simplePseudos.map((pseudo) => ({ [pseudo]: cssWithKeyframesSchema })),
   ),
 );
 
@@ -26,7 +26,7 @@ const fullStyle = cssWithSimplePseudos.append({
   selectors: selectorsSchema,
 });
 
-const makeMediaQuerySchema = (valueSchema: ObjectSchema) =>
+const makeQuerySchema = (valueSchema: ObjectSchema) =>
   valueSchema
     .append({
       '@media': joi.object().pattern(joi.string(), valueSchema),
@@ -35,9 +35,9 @@ const makeMediaQuerySchema = (valueSchema: ObjectSchema) =>
       '@supports': joi.object().pattern(joi.string(), valueSchema),
     });
 
-const fullStyleWithMedia = makeMediaQuerySchema(fullStyle).required();
+const fullStyleWithMedia = makeQuerySchema(fullStyle).required();
 
-const globalStyleWithMedia = makeMediaQuerySchema(
+const globalStyleWithMedia = makeQuerySchema(
   fullStyle.forbiddenKeys('selectors', ...simplePseudos),
 ).required();
 

--- a/packages/treat/tests/__snapshots__/stylesheet.test.ts.snap
+++ b/packages/treat/tests/__snapshots__/stylesheet.test.ts.snap
@@ -951,6 +951,80 @@ html ._1-2GZ_small_theme_1l {
 "
 `;
 
+exports[`Stylesheet Feature queries - Autoprefixer (iOS 8) - should create a deterministic stylesheet 1`] = `
+"._3rC2M {
+    display: block
+}
+@supports (display: grid) {
+    ._3rC2M {
+        display: grid
+    }
+}
+@supports not (display: grid) {
+    ._3rC2M {
+        display: -webkit-flex;
+        display: flex
+    }
+}
+"
+`;
+
+exports[`Stylesheet Feature queries - Custom idents - should create a deterministic stylesheet 1`] = `
+".feature-queries-feature-queries_3rC2M {
+    display: block
+}
+@supports (display: grid) {
+    .feature-queries-feature-queries_3rC2M {
+        display: grid
+    }
+}
+@supports not (display: grid) {
+    .feature-queries-feature-queries_3rC2M {
+        display: flex
+    }
+}
+"
+`;
+
+exports[`Stylesheet Feature queries - Development mode - should create a deterministic stylesheet 1`] = `
+".feature-queries-feature-queries_3rC2M {
+    display: block
+}
+@supports (display: grid) {
+    .feature-queries-feature-queries_3rC2M {
+        display: grid
+    }
+}
+@supports not (display: grid) {
+    .feature-queries-feature-queries_3rC2M {
+        display: flex
+    }
+}
+"
+`;
+
+exports[`Stylesheet Feature queries - Production mode - should create a deterministic stylesheet 1`] = `
+"._3rC2M{display:block}@supports (display:grid){._3rC2M{display:grid}}@supports not (display:grid){._3rC2M{display:flex}}
+"
+`;
+
+exports[`Stylesheet Feature queries - Theme function ident - should create a deterministic stylesheet 1`] = `
+"._3rC2M {
+    display: block
+}
+@supports (display: grid) {
+    ._3rC2M {
+        display: grid
+    }
+}
+@supports not (display: grid) {
+    ._3rC2M {
+        display: flex
+    }
+}
+"
+`;
+
 exports[`Stylesheet Multi file - Autoprefixer (iOS 8) - should create a deterministic stylesheet 1`] = `
 "._3jirG {
     color: blue

--- a/packages/treat/tests/fixtures/feature-queries/feature-queries.treat.ts
+++ b/packages/treat/tests/fixtures/feature-queries/feature-queries.treat.ts
@@ -1,0 +1,13 @@
+import { style } from 'treat';
+
+export default style({
+  display: 'block',
+  '@supports': {
+    '(display: grid)': {
+      display: 'grid',
+    },
+    'not (display: grid)': {
+      display: 'flex',
+    },
+  },
+});

--- a/packages/treat/tests/fixtures/feature-queries/index.ts
+++ b/packages/treat/tests/fixtures/feature-queries/index.ts
@@ -1,0 +1,13 @@
+import styles from './feature-queries.treat';
+
+const node = document.createElement('div');
+
+node.setAttribute('id', 'main');
+node.appendChild(
+  document.createTextNode(
+    'This is a grid container if the browser supports it',
+  ),
+);
+node.setAttribute('class', `${styles}`);
+
+document.body.appendChild(node);

--- a/packages/treat/tests/stylesheet.test.ts
+++ b/packages/treat/tests/stylesheet.test.ts
@@ -107,6 +107,10 @@ const fixtureEntries = [
     fixtureName: 'Animations',
     entry: './fixtures/animations/index.ts',
   },
+  {
+    fixtureName: 'Feature queries',
+    entry: './fixtures/feature-queries/index.ts',
+  },
 ];
 
 describe('Stylesheet', () => {


### PR DESCRIPTION
Support **@supports** queries:

```js
export const myStyle = style({
  '@supports': {
    '(display: grid)': {
      display: 'grid',
    },
    'not (display: grid)': {
      display: 'flex',
    },
  },
})
```
closes https://github.com/seek-oss/treat/issues/131