### PR TITLE
🐛 Fix global theme type definition file name

### DIFF
--- a/docs/data-types.md
+++ b/docs/data-types.md
@@ -124,7 +124,7 @@ theme => ({
 
 When [defining themes](styling-api#createtheme) and [consuming themes](#themedstyles), the provided theme object uses the `Theme` type, which is `any` by default. This means that any usage of a theme will not be type-safe.
 
-The simplest way to fix this is to override this type at a global level. For example, you could create a `treat.d.ts` file in your project with the following contents.
+The simplest way to fix this is to override this type at a global level. For example, you could create a `theme.d.ts` file in your project with the following contents.
 
 ```tsx
 declare module 'treat/theme' {


### PR DESCRIPTION
When using `treat.d.ts` TS throws errors:

```
File '/[...]/treat.d.ts' is not a module.
```