### PR TITLE
Fix style exports not being available when window is defined

### DIFF
--- a/.changeset/tender-rice-switch.md
+++ b/.changeset/tender-rice-switch.md
@@ -1,0 +1,5 @@
+---
+'treat': patch
+---
+
+Fix style exports not being available when window is defined

--- a/cleanup-browser-exports.js
+++ b/cleanup-browser-exports.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const fs = require('fs/promises');
+
+const cleanupFiles = [
+  path.join(__dirname, 'packages/treat/dist/treat.cjs.dev.js'),
+  path.join(__dirname, 'packages/treat/dist/treat.cjs.prod.js'),
+  path.join(__dirname, 'packages/treat/dist/treat.esm.js'),
+];
+
+async function run() {
+  for (const filePath of cleanupFiles) {
+    const contents = await fs.readFile(filePath, 'utf-8');
+
+    const newContents = contents.replace(
+      /typeof window === 'undefined' \? (createTheme|style|styleMap|styleTree|globalStyle) : null/g,
+      '$1',
+    );
+
+    await fs.writeFile(filePath, newContents, 'utf-8');
+  }
+}
+
+run();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prebuild-docs": "yarn make-docs-manifest",
     "start-docs": "webpack-dev-server --config ./site/webpack.config.js",
     "build-docs": "NODE_ENV=production webpack --config ./site/webpack.config.js",
-    "build": "preconstruct build",
+    "build": "preconstruct build && node ./cleanup-browser-exports",
     "dev": "preconstruct dev",
     "release": "yarn build && yarn build-docs && changeset publish && node ./site/deploy.js",
     "debug-fixture": "node ./test-helpers/debugFixture.js"


### PR DESCRIPTION
This is probably the biggest hack I've ever done in my life. But I'm honestly stuck for ideas about how else to resolve the issue without asking for changes in `preconstruct`, or dropping it entirely. 

Resolves #165 