### PR TITLE
Update compat.js

### DIFF
--- a/packages/treat/src/webpack-plugin/compat.js
+++ b/packages/treat/src/webpack-plugin/compat.js
@@ -42,7 +42,7 @@ const webpack5 = {
   isModuleUsed: (compilation, module) => {
     const exportsInfo = compilation.moduleGraph.getExportsInfo(module);
 
-    return exportsInfo.isModuleUsed('main');
+    return exportsInfo.isModuleUsed('runtime');
   },
   getDependencyModule: (compilation, dependency) =>
     compilation.moduleGraph.getModule(dependency),


### PR DESCRIPTION
Change exportsInfo.moduleUsed() to look in runtime rather than main. I don't really understand the specifics here but hoping its enough to at least help find a proper fix if this isn't going to actually determine whether the module is used or not.

Fixes #173 