### PR TITLE
Check all runtimes for usage before marking CSS for removals

### DIFF
--- a/.changeset/nine-pots-judge.md
+++ b/.changeset/nine-pots-judge.md
@@ -1,0 +1,5 @@
+---
+'treat': patch
+---
+
+Check all runtimes for usage before marking CSS for removals

--- a/packages/treat/src/webpack-plugin/compat.js
+++ b/packages/treat/src/webpack-plugin/compat.js
@@ -42,7 +42,7 @@ const webpack5 = {
   isModuleUsed: (compilation, module) => {
     const exportsInfo = compilation.moduleGraph.getExportsInfo(module);
 
-    return exportsInfo.isModuleUsed('main');
+    return exportsInfo.isModuleUsed();
   },
   getDependencyModule: (compilation, dependency) =>
     compilation.moduleGraph.getModule(dependency),


### PR DESCRIPTION
Turns out passing nothing to `isModuleUsed` makes it check all existing runtimes. Not 100% sure what makes the runtime names differ but either way I think this is more correct. 

Resolves #173 